### PR TITLE
Add support to boot images via iPXE

### DIFF
--- a/pkg/provider/apis/provider_spec.go
+++ b/pkg/provider/apis/provider_spec.go
@@ -31,6 +31,7 @@ type EquinixMetalProviderSpec struct {
 	MachineType    string   `json:"machineType"`
 	BillingCycle   string   `json:"billingCycle"`
 	OS             string   `json:"OS"`
+	IPXEScriptURL  string   `json:"ipxeScriptUrl,omitempty"`
 	ProjectID      string   `json:"projectID"`
 	Tags           []string `json:"tags,omitempty"`
 	SSHKeys        []string `json:"sshKeys,omitempty"`

--- a/pkg/provider/apis/provider_spec.go
+++ b/pkg/provider/apis/provider_spec.go
@@ -30,7 +30,7 @@ type EquinixMetalProviderSpec struct {
 	Facilities     []string `json:"facilities"`
 	MachineType    string   `json:"machineType"`
 	BillingCycle   string   `json:"billingCycle"`
-	OS             string   `json:"OS"`
+	OS             string   `json:"OS,omitempty"`
 	IPXEScriptURL  string   `json:"ipxeScriptUrl,omitempty"`
 	ProjectID      string   `json:"projectID"`
 	Tags           []string `json:"tags,omitempty"`

--- a/pkg/provider/apis/validation/validation.go
+++ b/pkg/provider/apis/validation/validation.go
@@ -49,8 +49,8 @@ func ValidateProviderSpec(spec *api.EquinixMetalProviderSpec, fldPath *field.Pat
 		allErrs = field.ErrorList{}
 	)
 
-	if "" == spec.OS {
-		allErrs = append(allErrs, field.Required(fldPath.Child("os"), "OS is required"))
+	if "" == spec.OS && "" == spec.IPXEScriptURL {
+		allErrs = append(allErrs, field.Required(fldPath.Child("os"), "OS or IPXEScriptURL is required"))
 	}
 	if "" == spec.MachineType {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineType"), "Machine Type is required"))

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -364,6 +364,9 @@ func decodeProviderSpec(machineClass *v1alpha1.MachineClass) (*api.EquinixMetalP
 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	if providerSpec.IPXEScriptURL != "" {
+		providerSpec.OS = "custom_ipxe"
+	}
 
 	return providerSpec, nil
 }

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -18,10 +18,12 @@ limitations under the License.
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	api "github.com/gardener/machine-controller-manager-provider-equinix-metal/pkg/provider/apis"
@@ -369,6 +371,7 @@ func decodeProviderSpec(machineClass *v1alpha1.MachineClass) (*api.EquinixMetalP
 func createDeviceWithReservations(svc packngo.DeviceService, createRequest *packngo.DeviceCreateRequest, reservationIDs []string, reservedOnly bool) (device *packngo.Device, err error) {
 	// if there were no reservation IDs and I didn't ask for reservedOnly, then just create one on-demand and return
 	if len(reservationIDs) == 0 && !reservedOnly {
+		klog.V(2).Info("No reservation ids provided, creating a on demand instance")
 		device, _, err = svc.Create(createRequest)
 		return device, err
 	}
@@ -377,11 +380,17 @@ func createDeviceWithReservations(svc packngo.DeviceService, createRequest *pack
 	// In both cases, we try reservations first.
 	for _, resID := range reservationIDs {
 		createRequest.HardwareReservationID = resID
-		device, _, err = svc.Create(createRequest)
+		var res *packngo.Response
+		device, res, err = svc.Create(createRequest)
 		// if no error, we got the device, return it
 		if err == nil {
 			return device, err
 		}
+		body := bytes.NewBuffer([]byte{})
+		if _, err := ioutil.ReadAll(res.Request.Body); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Error while creating machine with reservation id %s: Request: %s Error: %v", resID, body.String(), err)
 	}
 	// if we got here, we failed to get a device with the given hardware reservation
 	if reservedOnly {

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -126,6 +126,7 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 		Metro:          providerSpec.Metro,
 		Facility:       providerSpec.Facilities,
 		OS:             providerSpec.OS,
+		IPXEScriptURL:  providerSpec.IPXEScriptURL,
 		ProjectSSHKeys: providerSpec.SSHKeys,
 		Tags:           providerSpec.Tags,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

See the https://github.com/gardener/gardener-extension-provider-equinix-metal/pull/279 for a detailed description.


It also adds better error handling and debug logs for failed request to the cloud provider

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add support to specify custom images via iPXE boot.
```
