### PR TITLE
 Moved Declaration of dynamic content from Makefile to .env file for Equinix-Metal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /tmp/*
 /dev
 /logs
-
+.env
 .vscode
 .idea
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,8 @@ IMAGE_REPOSITORY    := <link-to-image-repo>
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := SampleProvider
 PROJECT_NAME        := gardener
-CONTROL_NAMESPACE  := default
-CONTROL_KUBECONFIG := dev/target-kubeconfig.yaml
-TARGET_KUBECONFIG  := dev/target-kubeconfig.yaml
+
+include .env
 
 #########################################
 # Rules for running helper scripts

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := SampleProvider
 PROJECT_NAME        := gardener
 
-include .env
+-include .env
 
 #########################################
 # Rules for running helper scripts

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include .env
+
 BINARY_PATH         := bin/
 COVERPROFILE        := test/output/coverprofile.out
 IMAGE_REPOSITORY    := <link-to-image-repo>
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := SampleProvider
 PROJECT_NAME        := gardener
-
--include .env
 
 #########################################
 # Rules for running helper scripts


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefile content to import dynamic content from the .env file.

**Which issue(s) this PR fixes**:
Fixes -> https://github.com/gardener/machine-controller-manager/issues/846

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
