### PR TITLE
Switch from GCR to GAR

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -49,7 +49,7 @@ machine-controller-manager-provider-equinix-metal:
           channel_cfgs:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
-              slack_cfg_name: 'scp_workspace'
+              slack_cfg_name: 'ti_workspace_writeonly'
         component_descriptor:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,8 +15,10 @@ machine-controller-manager-provider-equinix-metal:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-equinix-metal'
+            registry: 'gcp-opensource'
+            image: 'europe-docker.pkg.dev/gardener-project/snapshots/gardener/machine-controller-manager-provider-equinix-metal'
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
     steps:
       check:
         image: 'golang:1.20.4'
@@ -28,7 +30,6 @@ machine-controller-manager-provider-equinix-metal:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
         options:
           public_build_logs: true
@@ -49,4 +50,15 @@ machine-controller-manager-provider-equinix-metal:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            machine-controller-manager-provider-equinix-metal:
+              inputs:
+                repos:
+                  source: ~ # default
+                steps:
+                  build: ~
+              registry: 'gcp-opensource'
+              image: 'europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-equinix-metal'

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: machine-controller-manager
-        image:eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.38.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager:v0.38.0
         imagePullPolicy: Always
         command:
           - ./machine-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjusts pipeline(s) to publish images and OCM-component-descriptors to `Google Artifact Registry`, rather than `Google Container Registry`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
