### PR TITLE
Add todo about broken .ci/verify-script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,8 @@ jobs:
     strategy:
       matrix:
         script:
-          # - .ci/check
+          # - .ci/check - broken, probably due to golang-version-upgrade which needs to be
+          #               reflected in source-tree (commented-out to unblock pipeline)
           - .ci/build
           - .ci/test
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:

This pullrequest is a reminder to fix `.ci/verify`-script. It is likely broken due to an upstream upgrade of golang-version, which needs to be reflected in local source-tree.

This error correlates with [migration to GitHub-Actions](https://github.com/gardener/machine-controller-manager-provider-equinix-metal/pull/31), but I believe it is not related (so I chose to shortcut this, and leave fixing to codeowners :-)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
